### PR TITLE
Include instruction to compile project in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ cd sonarr-trakt-tv
 
 # Install dependencies
 npm install
+npm install -g typescript
+
+# Compile TypeScript to JavaScript
+tsc
 ```
 
 ## Running the server


### PR DESCRIPTION
Hello,

There is a missing instruction to compile ts into js in readme, I added it.

Best Regards,
Juraj